### PR TITLE
Add Playwright ESLint plugin configuration for end-to-end tests

### DIFF
--- a/template/eslint.config.js
+++ b/template/eslint.config.js
@@ -3,6 +3,7 @@ import vitest from '@vitest/eslint-plugin';
 import importPlugin from 'eslint-plugin-import';
 import jestDom from 'eslint-plugin-jest-dom';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
+import playwright from 'eslint-plugin-playwright';
 import eslintPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
@@ -26,7 +27,7 @@ export default defineConfig([
   eslintPrettierRecommended,
   jsxA11y.flatConfigs.recommended,
   {
-    ignores: ['tests/.features-gen']
+    ignores: ['tests/.features-gen'],
   },
   {
     settings: {
@@ -161,6 +162,19 @@ export default defineConfig([
 
       // eslint-plugin-testing-library https://github.com/testing-library/eslint-plugin-testing-library
       'testing-library/prefer-query-matchers': 'error',
+    },
+  },
+  {
+    ...playwright.configs['flat/recommended'],
+    files: ['tests/**/*.{js,jsx,mjs,cjs,ts,tsx,cts,mts}'],
+    rules: {
+      ...playwright.configs['flat/recommended'].rules,
+      'playwright/prefer-to-have-length': 'error',
+      'playwright/prefer-to-have-count': 'error',
+      'playwright/prefer-to-contain': 'error',
+      'playwright/prefer-strict-equal': 'error',
+      // With playwright-bdd, all expects will be defined outside of test blocks
+      'playwright/no-standalone-expect': 'off',
     },
   },
   {

--- a/template/package.json
+++ b/template/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-playwright": "^2.2.0",
     "eslint-plugin-prettier": "^5.4.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",


### PR DESCRIPTION
**Type of Pull Request :**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue :**

N/A

**Context :**

This Pull Request introduces the Playwright ESLint plugin configuration to improve the quality and consistency of end-to-end tests. Integrating this plugin enforces Playwright-specific rules and helps prevent common mistakes when writing tests.

**Proposed Changes :**

- Add `eslint-plugin-playwright` to ESLint configuration.
- Apply recommended Playwright rules to end-to-end test files.
- Enforce additional Playwright best practices (`prefer-to-have-length`, `prefer-to-have-count`, `prefer-to-contain`, `prefer-strict-equal`).
- Disable `playwright/no-standalone-expect` for compatibility with `playwright-bdd`.

**Checklist :**

- [x] I have verified that my changes work as expected
- [ ] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

N/A