### PR TITLE
Enable React StrictMode in AppHTMLElement and Update Related Tests

### DIFF
--- a/template/src/App/AppHTMLElement.tsx
+++ b/template/src/App/AppHTMLElement.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { App } from './App';
 
@@ -11,7 +12,11 @@ export class AppHTMLElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.root.render(<App />);
+    this.root.render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
   }
 
   disconnectedCallback() {

--- a/template/src/App/__tests__/AppHTMLElement.test.tsx
+++ b/template/src/App/__tests__/AppHTMLElement.test.tsx
@@ -1,4 +1,5 @@
 import { waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { App } from '../App';
@@ -35,7 +36,11 @@ describe('AppHTMLElement', () => {
     document.body.appendChild(container);
 
     expect(createRoot as Mock).toHaveBeenCalledWith(expect.anything());
-    expect(render).toBeCalledWith(<App />);
+    expect(render).toBeCalledWith(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
     expect(unmount).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
**Type of Pull Request :**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue :**

N/A

**Context :**

This Pull Request introduces React's StrictMode to the `AppHTMLElement` custom element. Enabling StrictMode helps identify potential problems in the application by activating additional checks and warnings for its descendants. The related unit tests have also been updated to reflect this change.

**Proposed Changes :**

- Import and wrap the `<App />` component with `<StrictMode>` in `AppHTMLElement.tsx`.
- Update the test in `AppHTMLElement.test.tsx` to expect `<App />` to be rendered within `<StrictMode>`.
- Ensure mocks and assertions in the test file are compatible with the new rendering logic.

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

No breaking changes are introduced. This update is a step towards improving code quality and future-proofing the application.