### PR TITLE
fix: ensure proper unmounting for ANDI compatibility

### DIFF
--- a/template/src/App/AppHTMLElement.tsx
+++ b/template/src/App/AppHTMLElement.tsx
@@ -20,6 +20,6 @@ export class AppHTMLElement extends HTMLElement {
   }
 
   disconnectedCallback() {
-    queueMicrotask(() => this.root.unmount());
+    this.root.unmount();
   }
 }


### PR DESCRIPTION
**Type of Pull Request :**

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue :**

N/A

**Context :**

This Pull Request addresses a compatibility issue with the ANDI accessibility tool. When ANDI manipulates the DOM, it can cause the custom element containing the React application to be removed and reinserted. Previously, the use of `queueMicrotask` in the `disconnectedCallback` could lead to timing issues, preventing the React app from remounting correctly. This fix ensures that the unmounting of the React root is immediate and predictable, allowing the application to function properly with ANDI.

**Proposed Changes :**

- Remove the use of `queueMicrotask` in the `disconnectedCallback` of `AppHTMLElement`.
- Call `this.root.unmount()` directly in `disconnectedCallback` to ensure immediate unmounting.
- This change guarantees that the React application is properly unmounted and can be remounted when the custom element is reinserted into the DOM, improving compatibility with ANDI.

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

No additional information. This fix is specifically targeted at improving accessibility tool compatibility.